### PR TITLE
Add default passported text to CYA IOJ

### DIFF
--- a/app/views/application_cert_review.html
+++ b/app/views/application_cert_review.html
@@ -433,65 +433,56 @@
 
     <br>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-m">Next court hearing</h2>
+    {% if data.case_details.urn_provided == 'no' %}
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-heading-m">Next court hearing</h2>
+        </div>
+        <div class="govuk-grid-column-one-third">
+        </div>
       </div>
-      <div class="govuk-grid-column-one-third">
-      </div>
-    </div>
 
-    <dl class="govuk-summary-list">
-      {% if data.case_details.urn_provided == 'no' %}
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Court name
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{ data['court-name'] }}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="/case_details_hearing">
-            Change<span class="govuk-visually-hidden">court name</span>
-          </a>
-        </dd>
-      </div>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Date of next hearing
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{ data['case_details']['next_hearing'] }}
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="/case_details_hearing">
-            Change<span class="govuk-visually-hidden">date of next hearing</span>
-          </a>
-        </dd>
-      </div>
-      {% else %}
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Details on VCD
-        </dt>
-        <dd class="govuk-summary-list__value">
-          {{ data['case_details']['urn'] }}
-        </dd>
-      </div>
-      {% endif %}
-    </dl>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Court name
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['court-name'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/case_details_hearing">
+              Change<span class="govuk-visually-hidden">court name</span>
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Date of next hearing
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['case_details']['next_hearing'] }}
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link" href="/case_details_hearing">
+              Change<span class="govuk-visually-hidden">date of next hearing</span>
+            </a>
+          </dd>
+        </div>
+      </dl>
+    {% endif %}
 
     <br>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h2 class="govuk-heading-m">Justification for legal aid</h2>
-        </div>
-        <div class="govuk-grid-column-one-third">
-          <p><a class="govuk-link" style="float:right;" href="/ioj">Change</a></p>
-        </div>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">Justification for legal aid</h2>
       </div>
-
+      <div class="govuk-grid-column-one-third">
+        <p><a class="govuk-link" style="float:right;" href="/ioj">Change</a></p>
+      </div>
+    </div>
+    {% if data['interests_of_justice'].length > 0 -%}
       <dl class="govuk-summary-list">
         {% for ioj in data['interests_of_justice'] -%}
           <div class="govuk-summary-list__row">
@@ -524,6 +515,19 @@
           </div>
         {%- endfor %}
       </dl>
+    {% else %}
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Passported
+          </dt>
+          <dd>
+            Case details provided do not require further justification for legal aid
+          </dd>
+          <br>
+        </div>
+      </dl>
+    {% endif %}
 
   <!-- FOR PASSPORTED CASES, THE CHECK YOUR ANSWERS FINISHES HERE -->
 

--- a/app/views/application_certificate.html
+++ b/app/views/application_certificate.html
@@ -340,44 +340,34 @@
         </dl>
 
         <br>
+        {% if data.case_details.urn_provided == 'no' %}
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <h2 class="govuk-heading-m">Next court hearing</h2>
+            </div>
+            <div class="govuk-grid-column-one-third">
+            </div>
+          </div>
 
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
-            <h2 class="govuk-heading-m">Next court hearing</h2>
-          </div>
-          <div class="govuk-grid-column-one-third">
-          </div>
-        </div>
-
-        <dl class="govuk-summary-list">
-          {% if data.case_details.urn_provided == 'no' %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Court name
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['court-name'] }}
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row"> 
-            <dt class="govuk-summary-list__key">
-              Date of next hearing
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['case_details']['next_hearing'] }}
-            </dd>
-          </div>
-          {% else %}
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              Details on VCD
-            </dt>
-            <dd class="govuk-summary-list__value">
-              {{ data['case_details']['urn'] }}
-            </dd>
-          </div>
-          {% endif %}
-        </dl>
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Court name
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['court-name'] }}
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Date of next hearing
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ data['case_details']['next_hearing'] }}
+              </dd>
+            </div>
+          </dl>
+        {% endif %}
 
         <br>
 
@@ -386,39 +376,52 @@
             <h2 class="govuk-heading-m">Justification for legal aid</h2>
           </div>
         </div>
-
-        <dl class="govuk-summary-list">
-          {% for ioj in data['interests_of_justice'] -%}
+        {% if data['interests_of_justice'].length > 0 -%}
+          <dl class="govuk-summary-list">
+            {% for ioj in data['interests_of_justice'] -%}
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  {% if ioj == 'liberty' %}
+                    Loss of liberty
+                  {% elif ioj == 'suspended_sentence' %}
+                    Suspended or non-custodial sentence
+                  {% elif ioj == 'livelihood' %}
+                    Loss of livelihood
+                  {% elif ioj == 'reputation' %}
+                    Serious damage to their reputation
+                  {% elif ioj == 'question_of_law' %}
+                    Substantial question of law may be involved
+                  {% elif ioj == 'unable_to_understand' %}
+                    Unable to understand the court proceedings or present own case
+                  {% elif ioj == 'witnesses_needed' %}
+                    Witnesses may need to be traced or interviewed
+                  {% elif ioj == 'expert_cross_examination' %}
+                    The proceedings may involve expert cross-examination
+                  {% elif ioj == 'interests_of_another' %}
+                    It is in the interests of another person
+                  {% elif ioj == 'ioj_other' %}
+                    Other reason
+                  {% endif %}
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ data['more-detail'][loop.index-1] }}
+                </dd>
+              </div>
+            {%- endfor %}
+          </dl>
+        {% else %}
+          <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                {% if ioj == 'liberty' %}
-                  Loss of liberty
-                {% elif ioj == 'suspended_sentence' %}
-                  Suspended or non-custodial sentence
-                {% elif ioj == 'livelihood' %}
-                  Loss of livelihood
-                {% elif ioj == 'reputation' %}
-                  Serious damage to their reputation
-                {% elif ioj == 'question_of_law' %}
-                  Substantial question of law may be involved
-                {% elif ioj == 'unable_to_understand' %}
-                  Unable to understand the court proceedings or present own case
-                {% elif ioj == 'witnesses_needed' %}
-                  Witnesses may need to be traced or interviewed
-                {% elif ioj == 'expert_cross_examination' %}
-                  The proceedings may involve expert cross-examination
-                {% elif ioj == 'interests_of_another' %}
-                  It is in the interests of another person
-                {% elif ioj == 'ioj_other' %}
-                  Other reason
-                {% endif %}
+                Passported
               </dt>
-              <dd class="govuk-summary-list__value">
-                {{ data['more-detail'][loop.index-1] }}
+              <dd>
+                Case details provided do not require further justification for legal aid
               </dd>
+              <br>
             </div>
-          {%- endfor %}
-        </dl>
+          </dl>
+        {% endif %}
 
         <br>
       </div>


### PR DESCRIPTION
This passported text is shown on the CYA and certs based on the provider not selecting an ioj reason. I don't know the routing logic that would not show the ioj page at all - but I can fix this if it's too hacky as is